### PR TITLE
Fix cofins

### DIFF
--- a/dist/utils/make.js
+++ b/dist/utils/make.js
@@ -451,11 +451,11 @@ class Make {
     tagProdCOFINS(index, obj) {
         if (__classPrivateFieldGet(this, _Make_NFe, "f").infNFe.det[index].imposto.COFINS === undefined)
             __classPrivateFieldGet(this, _Make_NFe, "f").infNFe.det[index].imposto.COFINS = {};
-        let keyXML = null;
+        let keyXML;
         switch (obj.CST) {
             case '01':
             case '02':
-                keyXML = null;
+                keyXML = "COFINSAliq";
                 break;
             case '03':
                 keyXML = "COFINSQtde";
@@ -494,18 +494,13 @@ class Make {
             case '99':
                 keyXML = "COFINSOutr";
                 break;
+            default:
+                throw new Error(`CST COFINS inválido: ${obj.CST}`);
         }
-        if (keyXML == null) {
-            Object.keys(obj).forEach(key => {
-                __classPrivateFieldGet(this, _Make_NFe, "f").infNFe.det[index].imposto.COFINS[key] = obj[key];
-            });
-        }
-        else {
-            __classPrivateFieldGet(this, _Make_NFe, "f").infNFe.det[index].imposto.COFINS[keyXML] = {};
-            Object.keys(obj).forEach(key => {
-                __classPrivateFieldGet(this, _Make_NFe, "f").infNFe.det[index].imposto.COFINS[keyXML][key] = obj[key];
-            });
-        }
+        __classPrivateFieldGet(this, _Make_NFe, "f").infNFe.det[index].imposto.COFINS[keyXML] = {};
+        Object.keys(obj).forEach(key => {
+            __classPrivateFieldGet(this, _Make_NFe, "f").infNFe.det[index].imposto.COFINS[keyXML][key] = obj[key];
+        });
         //Calcular ICMSTot
         __classPrivateFieldGet(this, _Make_instances, "m", _Make_calICMSTot).call(this, obj);
     }

--- a/src/utils/make.ts
+++ b/src/utils/make.ts
@@ -480,11 +480,11 @@ class Make {
     tagProdCOFINS(index: number, obj: any) {
         if (this.#NFe.infNFe.det[index].imposto.COFINS === undefined) this.#NFe.infNFe.det[index].imposto.COFINS = {};
 
-        let keyXML = null;
+        let keyXML: string;
         switch (obj.CST) {
             case '01':
             case '02':
-                keyXML = null;
+                keyXML = "COFINSAliq";
                 break;
             case '03':
                 keyXML = "COFINSQtde";
@@ -523,18 +523,14 @@ class Make {
             case '99':
                 keyXML = "COFINSOutr";
                 break;
+            default:
+                throw new Error(`CST COFINS inválido: ${obj.CST}`);
         }
 
-        if (keyXML == null) {
-            Object.keys(obj).forEach(key => {
-                this.#NFe.infNFe.det[index].imposto.COFINS[key] = obj[key];
-            });
-        } else {
-            this.#NFe.infNFe.det[index].imposto.COFINS[keyXML] = {};
-            Object.keys(obj).forEach(key => {
-                this.#NFe.infNFe.det[index].imposto.COFINS[keyXML][key] = obj[key];
-            });
-        }
+        this.#NFe.infNFe.det[index].imposto.COFINS[keyXML] = {};
+        Object.keys(obj).forEach(key => {
+            this.#NFe.infNFe.det[index].imposto.COFINS[keyXML][key] = obj[key];
+        });
 
         //Calcular ICMSTot
         this.#calICMSTot(obj);


### PR DESCRIPTION
- Corrige tagProdCOFINS para criar subgrupo COFINSAliq para CST 01 e 02
- Remove lógica que colocava campos diretamente em COFINS
- Adiciona tratamento de erro para CSTs inválidos
- Resolve erro de schema XML: 'COFINS has invalid child element CST'