### PR TITLE
Fix urlEventos

### DIFF
--- a/dist/utils/eventos.d.ts
+++ b/dist/utils/eventos.d.ts
@@ -1,2 +1,2 @@
-declare function urlEventos(UF: string, versao: string): any;
+declare function urlEventos(mod: string, UF: string, versao: string): any;
 export { urlEventos };

--- a/dist/utils/eventos.js
+++ b/dist/utils/eventos.js
@@ -1,5 +1,5 @@
-import event55 from "./webservices/mod55";
-import event65 from "./webservices/mod65";
+import event55 from "./webservices/mod55.js";
+import event65 from "./webservices/mod65.js";
 function urlEventos(mod, UF, versao) {
     switch (`${versao}`) {
         case "4.00":

--- a/dist/utils/eventos.js
+++ b/dist/utils/eventos.js
@@ -1,12 +1,17 @@
 import event55 from "./webservices/mod55";
 import event65 from "./webservices/mod65";
-function urlEventos(UF, versao) {
+function urlEventos(mod, UF, versao) {
     switch (`${versao}`) {
         case "4.00":
-            return {
-                mod65: event65.eventos(UF),
-                mod55: event55.eventos(UF)
-            };
+            switch (mod) {
+                case "mod65":
+                    return event65.eventos(UF);
+                case "mod55":
+                    return event55.eventos(UF);
+                default:
+                    throw `Modulo incompativel! Tools({...mod:${mod}})`;
+                    break;
+            }
         default:
             throw `Versão incompativel! Tools({...versao:${versao}})`;
             break;

--- a/dist/utils/make.js
+++ b/dist/utils/make.js
@@ -732,10 +732,10 @@ class Make {
         //Adicionar QrCode
         if (__classPrivateFieldGet(this, _Make_NFe, "f").infNFe.ide.mod * 1 == 65) {
             //Como ja temos cUF, vamos usar o extras.cUF2UF
-            let tempUF = urlEventos(cUF2UF[__classPrivateFieldGet(this, _Make_NFe, "f").infNFe.ide.cUF], __classPrivateFieldGet(this, _Make_NFe, "f").infNFe['@versao']);
+            let tempUF = urlEventos("mod65", cUF2UF[__classPrivateFieldGet(this, _Make_NFe, "f").infNFe.ide.cUF], __classPrivateFieldGet(this, _Make_NFe, "f").infNFe['@versao']);
             __classPrivateFieldGet(this, _Make_NFe, "f").infNFeSupl = {
-                qrCode: tempUF.mod65[__classPrivateFieldGet(this, _Make_NFe, "f").infNFe.ide.tpAmb == 1 ? 'producao' : 'homologacao'].NFeConsultaQR, //Este não e o valor final, vamos utilizar apenas para carregar os dados que vão ser utlizados no make
-                urlChave: tempUF.mod65[__classPrivateFieldGet(this, _Make_NFe, "f").infNFe.ide.tpAmb == 1 ? 'producao' : 'homologacao'].urlChave
+                qrCode: tempUF[(__classPrivateFieldGet(this, _Make_NFe, "f").infNFe.ide.tpAmb == 1 ? 'producao' : 'homologacao')].NFeConsultaQR, //Este não e o valor final, vamos utilizar apenas para carregar os dados que vão ser utlizados no make
+                urlChave: tempUF[(__classPrivateFieldGet(this, _Make_NFe, "f").infNFe.ide.tpAmb == 1 ? 'producao' : 'homologacao')].urlChave
             };
         }
         let tempBuild = new XMLBuilder({

--- a/dist/utils/tools.js
+++ b/dist/utils/tools.js
@@ -97,8 +97,7 @@ class Tools {
                 }
             });
             try {
-                let tempUF = urlEventos(__classPrivateFieldGet(this, _Tools_config, "f").UF, __classPrivateFieldGet(this, _Tools_config, "f").versao);
-                const req = https.request(tempUF[`mod${__classPrivateFieldGet(this, _Tools_config, "f").mod}`][(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeInutilizacao, {
+                const req = https.request(urlEventos(__classPrivateFieldGet(this, _Tools_config, "f").mod, __classPrivateFieldGet(this, _Tools_config, "f").UF, __classPrivateFieldGet(this, _Tools_config, "f").versao)[(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeInutilizacao, {
                     ...{
                         method: 'POST',
                         headers: {
@@ -172,8 +171,7 @@ class Tools {
             };
             let xmlLote = await this.json2xml(jsonXmlLote);
             try {
-                let tempUF = urlEventos(__classPrivateFieldGet(this, _Tools_config, "f").UF, __classPrivateFieldGet(this, _Tools_config, "f").versao);
-                const req = https.request(tempUF[`mod${__classPrivateFieldGet(this, _Tools_config, "f").mod}`][(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeAutorizacao, {
+                const req = https.request(urlEventos(__classPrivateFieldGet(this, _Tools_config, "f").mod, __classPrivateFieldGet(this, _Tools_config, "f").UF, __classPrivateFieldGet(this, _Tools_config, "f").versao)[(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeAutorizacao, {
                     ...{
                         method: 'POST',
                         headers: {
@@ -304,8 +302,7 @@ class Tools {
                 await __classPrivateFieldGet(this, _Tools_instances, "m", _Tools_xmlValido).call(this, builder.build({ consSitNFe }), `consSitNFe_v${__classPrivateFieldGet(this, _Tools_config, "f").versao}`).catch(reject);
                 ;
                 const xml = builder.build(xmlObj);
-                let tempUF = urlEventos(UF, __classPrivateFieldGet(this, _Tools_config, "f").versao);
-                const url = tempUF[`mod${mod}`][(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeConsultaProtocolo;
+                const url = urlEventos(mod, UF, __classPrivateFieldGet(this, _Tools_config, "f").versao)[(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeConsultaProtocolo;
                 const req = https.request(url, {
                     method: 'POST',
                     headers: {
@@ -377,7 +374,6 @@ class Tools {
                     detEvento["xJust"] = xJust;
                 }
                 // Ciência (210210), Confirmação (210200), Desconhecimento (210220) não precisam de campos extras
-                const tempUF = urlEventos(cUF2UF[cOrgao], __classPrivateFieldGet(this, _Tools_config, "f").versao);
                 const evento = {
                     "envEvento": {
                         "@xmlns": "http://www.portalfiscal.inf.br/nfe",
@@ -417,7 +413,7 @@ class Tools {
                     }
                 });
                 try {
-                    const req = https.request(tempUF[`mod${chNFe.substring(20, 22)}`][(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeRecepcaoEvento, {
+                    const req = https.request(urlEventos(`mod${chNFe.substring(20, 22)}`, cUF2UF[cOrgao], __classPrivateFieldGet(this, _Tools_config, "f").versao)[(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeRecepcaoEvento, {
                         ...{
                             method: 'POST',
                             headers: {
@@ -496,7 +492,6 @@ class Tools {
                     }
                 });
                 await __classPrivateFieldGet(this, _Tools_instances, "m", _Tools_xmlValido).call(this, xmlSing, `distDFeInt_v1.01`).catch(reject); //Validar corpo
-                const tempUF = urlEventos(`AN`, __classPrivateFieldGet(this, _Tools_config, "f").versao);
                 xmlSing = await json2xml({
                     "soap:Envelope": {
                         "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
@@ -514,7 +509,7 @@ class Tools {
                     }
                 });
                 // HTTPS Request, trava modelo 55
-                const req = https.request(tempUF[`mod55`][(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeDistribuicaoDFe, {
+                const req = https.request(urlEventos("mod55", `AN`, __classPrivateFieldGet(this, _Tools_config, "f").versao)[(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeDistribuicaoDFe, {
                     ...{
                         method: 'POST',
                         headers: {
@@ -591,9 +586,8 @@ class Tools {
                 });
                 //Validação
                 await __classPrivateFieldGet(this, _Tools_instances, "m", _Tools_xmlValido).call(this, tempBuild.build({ consStatServ }), `consStatServ_v${__classPrivateFieldGet(this, _Tools_config, "f").versao}`).catch(reject);
-                let tempUF = urlEventos(__classPrivateFieldGet(this, _Tools_config, "f").UF, __classPrivateFieldGet(this, _Tools_config, "f").versao);
                 let xml = tempBuild.build(xmlObj);
-                const req = https.request(tempUF[`mod${__classPrivateFieldGet(this, _Tools_config, "f").mod}`][(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeStatusServico, {
+                const req = https.request(urlEventos(__classPrivateFieldGet(this, _Tools_config, "f").mod, __classPrivateFieldGet(this, _Tools_config, "f").UF, __classPrivateFieldGet(this, _Tools_config, "f").versao)[(__classPrivateFieldGet(this, _Tools_config, "f").tpAmb == 1 ? "producao" : "homologacao")].NFeStatusServico, {
                     ...{
                         method: 'POST',
                         headers: {

--- a/dist/utils/webservices/mod55.d.ts
+++ b/dist/utils/webservices/mod55.d.ts
@@ -39,6 +39,21 @@ declare const _default: {
                 NFeConsultaCadastro: string;
             };
         };
+    } | {
+        homologacao: {
+            NFeRecepcaoEvento: string;
+            NFeDistribuicaoDFe: string;
+            NFeConsultaDest: string;
+            NFeDownloadNF: string;
+            RecepcaoEPEC: string;
+        };
+        producao: {
+            NFeRecepcaoEvento: string;
+            NFeDistribuicaoDFe: string;
+            NFeConsultaDest: string;
+            NFeDownloadNF: string;
+            RecepcaoEPEC: string;
+        };
     };
     eventosCont: (UF: string) => {
         homologacao: {

--- a/dist/utils/webservices/mod55.js
+++ b/dist/utils/webservices/mod55.js
@@ -144,6 +144,23 @@ const eventos = (UF) => {
                     "NFeConsultaCadastro": ""
                 }
             };
+        case 'AN':
+            return {
+                "homologacao": {
+                    "NFeRecepcaoEvento": "https://hom1.nfe.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx",
+                    "NFeDistribuicaoDFe": "https://hom1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx",
+                    "NFeConsultaDest": "https://hom.nfe.fazenda.gov.br/NFeConsultaDest/NFeConsultaDest.asmx",
+                    "NFeDownloadNF": "https://hom.nfe.fazenda.gov.br/NfeDownloadNF/NfeDownloadNF.asmx",
+                    "RecepcaoEPEC": "https://hom.nfe.fazenda.gov.br/RecepcaoEvento/RecepcaoEvento.asmx"
+                },
+                "producao": {
+                    "NFeRecepcaoEvento": "https://www.nfe.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx",
+                    "NFeDistribuicaoDFe": "https://www1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx",
+                    "NFeConsultaDest": "https://www.nfe.fazenda.gov.br/NFeConsultaDest/NFeConsultaDest.asmx",
+                    "NFeDownloadNF": "https://www.nfe.fazenda.gov.br/NfeDownloadNF/NfeDownloadNF.asmx",
+                    "RecepcaoEPEC": "https://www.nfe.fazenda.gov.br/RecepcaoEvento/RecepcaoEvento.asmx"
+                }
+            };
         case 'BA':
             return {
                 "homologacao": {

--- a/src/utils/eventos.ts
+++ b/src/utils/eventos.ts
@@ -1,12 +1,17 @@
 import event55 from "./webservices/mod55"
 import event65 from "./webservices/mod65"
 
-function urlEventos(UF: string, versao: string): any {
+function urlEventos(mod: string, UF: string, versao: string): any {
     switch (`${versao}`) {
         case "4.00":
-            return {
-                mod65: event65.eventos(UF),
-                mod55: event55.eventos(UF)
+            switch (mod) {
+                case "mod65":
+                    return event65.eventos(UF)
+                case "mod55":
+                    return event55.eventos(UF)
+                default:
+                    throw `Modulo incompativel! Tools({...mod:${mod}})`;
+                    break;
             }
         default:
             throw `Versão incompativel! Tools({...versao:${versao}})`;

--- a/src/utils/make.ts
+++ b/src/utils/make.ts
@@ -861,10 +861,10 @@ class Make {
         //Adicionar QrCode
         if (this.#NFe.infNFe.ide.mod * 1 == 65) {
             //Como ja temos cUF, vamos usar o extras.cUF2UF
-            let tempUF = urlEventos(cUF2UF[this.#NFe.infNFe.ide.cUF], this.#NFe.infNFe['@versao']);
+            let tempUF = urlEventos("mod65", cUF2UF[this.#NFe.infNFe.ide.cUF], this.#NFe.infNFe['@versao']);
             this.#NFe.infNFeSupl = {
-                qrCode: tempUF.mod65[this.#NFe.infNFe.ide.tpAmb == 1 ? 'producao' : 'homologacao'].NFeConsultaQR, //Este não e o valor final, vamos utilizar apenas para carregar os dados que vão ser utlizados no make
-                urlChave: tempUF.mod65[this.#NFe.infNFe.ide.tpAmb == 1 ? 'producao' : 'homologacao'].urlChave
+                qrCode: tempUF[(this.#NFe.infNFe.ide.tpAmb == 1 ? 'producao' : 'homologacao')].NFeConsultaQR, //Este não e o valor final, vamos utilizar apenas para carregar os dados que vão ser utlizados no make
+                urlChave: tempUF[(this.#NFe.infNFe.ide.tpAmb == 1 ? 'producao' : 'homologacao')].urlChave
             }
         }
 

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -109,8 +109,7 @@ class Tools {
 
 
             try {
-                let tempUF = urlEventos(this.#config.UF, this.#config.versao);
-                const req = https.request(tempUF[`mod${this.#config.mod}`][(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeInutilizacao, {
+                const req = https.request(urlEventos(this.#config.mod, this.#config.UF, this.#config.versao)[(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeInutilizacao, {
                     ...{
                         method: 'POST',
                         headers: {
@@ -184,8 +183,7 @@ class Tools {
             }
             let xmlLote = await this.json2xml(jsonXmlLote);
             try {
-                let tempUF = urlEventos(this.#config.UF, this.#config.versao);
-                const req = https.request(tempUF[`mod${this.#config.mod}`][(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeAutorizacao, {
+                const req = https.request(urlEventos(this.#config.mod, this.#config.UF, this.#config.versao)[(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeAutorizacao, {
                     ...{
                         method: 'POST',
                         headers: {
@@ -384,9 +382,7 @@ class Tools {
 
                 const xml = builder.build(xmlObj);
 
-                let tempUF = urlEventos(UF, this.#config.versao);
-
-                const url = tempUF[`mod${mod}`][(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeConsultaProtocolo;
+                const url = urlEventos(mod, UF, this.#config.versao)[(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeConsultaProtocolo;
 
                 const req = https.request(url, {
                     method: 'POST',
@@ -454,7 +450,6 @@ class Tools {
                 }
                 // Ciência (210210), Confirmação (210200), Desconhecimento (210220) não precisam de campos extras
 
-                const tempUF = urlEventos(cUF2UF[cOrgao], this.#config.versao);
                 const evento = {
                     "envEvento": {
                         "@xmlns": "http://www.portalfiscal.inf.br/nfe",
@@ -497,7 +492,7 @@ class Tools {
                 });
 
                 try {
-                    const req = https.request(tempUF[`mod${chNFe.substring(20, 22)}`][(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeRecepcaoEvento, {
+                    const req = https.request(urlEventos(`mod${chNFe.substring(20, 22)}`, cUF2UF[cOrgao], this.#config.versao)[(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeRecepcaoEvento, {
                         ...{
                             method: 'POST',
                             headers: {
@@ -579,7 +574,6 @@ class Tools {
                 });
 
                 await this.#xmlValido(xmlSing, `distDFeInt_v1.01`).catch(reject); //Validar corpo
-                const tempUF = urlEventos(`AN`, this.#config.versao);
 
                 xmlSing = await json2xml({
                     "soap:Envelope": {
@@ -597,8 +591,9 @@ class Tools {
                         }
                     }
                 });
+                
                 // HTTPS Request, trava modelo 55
-                const req = https.request(tempUF[`mod55`][(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeDistribuicaoDFe, {
+                const req = https.request(urlEventos("mod55",`AN`, this.#config.versao)[(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeDistribuicaoDFe, {
                     ...{
                         method: 'POST',
                         headers: {
@@ -691,9 +686,8 @@ class Tools {
 
                 //Validação
                 await this.#xmlValido(tempBuild.build({ consStatServ }), `consStatServ_v${this.#config.versao}`).catch(reject);
-                let tempUF = urlEventos(this.#config.UF, this.#config.versao);
                 let xml = tempBuild.build(xmlObj);
-                const req = https.request(tempUF[`mod${this.#config.mod}`][(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeStatusServico, {
+                const req = https.request(urlEventos(this.#config.mod, this.#config.UF, this.#config.versao)[(this.#config.tpAmb == 1 ? "producao" : "homologacao")].NFeStatusServico, {
                     ...{
                         method: 'POST',
                         headers: {

--- a/src/utils/webservices/mod55.ts
+++ b/src/utils/webservices/mod55.ts
@@ -148,6 +148,23 @@ const eventos = (UF: string) => {
                     "NFeConsultaCadastro": ""
                 }
             };
+        case 'AN': 
+            return {
+                "homologacao": {
+                    "NFeRecepcaoEvento": "https://hom1.nfe.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx",
+                    "NFeDistribuicaoDFe": "https://hom1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx",
+                    "NFeConsultaDest": "https://hom.nfe.fazenda.gov.br/NFeConsultaDest/NFeConsultaDest.asmx",
+                    "NFeDownloadNF": "https://hom.nfe.fazenda.gov.br/NfeDownloadNF/NfeDownloadNF.asmx",
+                    "RecepcaoEPEC": "https://hom.nfe.fazenda.gov.br/RecepcaoEvento/RecepcaoEvento.asmx"
+                },
+                "producao": {
+                    "NFeRecepcaoEvento": "https://www.nfe.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx",
+                    "NFeDistribuicaoDFe": "https://www1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx",
+                    "NFeConsultaDest": "https://www.nfe.fazenda.gov.br/NFeConsultaDest/NFeConsultaDest.asmx",
+                    "NFeDownloadNF": "https://www.nfe.fazenda.gov.br/NfeDownloadNF/NfeDownloadNF.asmx",
+                    "RecepcaoEPEC": "https://www.nfe.fazenda.gov.br/RecepcaoEvento/RecepcaoEvento.asmx"
+                }
+            }
         case 'BA':
             return {
                 "homologacao": {


### PR DESCRIPTION
Todas as chamadas utilizando o urlEventos está usando o padrão antigo de retorno do eventos.ts
- Foi feito o update de todos os endpoints para utilizar a nova versão considerando o modo entre mod65 e mod55
- Adicionado AN ao switch case do mod55 que havia sido removido anteriormente.